### PR TITLE
Enable deep merging of env settings with default ones

### DIFF
--- a/utils/EnvironmentManager.js
+++ b/utils/EnvironmentManager.js
@@ -85,7 +85,7 @@ module.exports = function(grunt, options) {
 
     var activeEnv = self.getActiveEnvironment();
     var settings = loadSettings(activeEnv);
-    return grunt.util._.extend({}, defaultSettings, settings);
+    return grunt.util._.merge({}, defaultSettings, settings);
   };
 
   self.injectEnvironmentSettings = function() {


### PR DESCRIPTION
Consider the scenario:
- `default.yml`

``` yaml
url:
  base: 'some_url'
  other: 'some_string'
```
- `env.yml`

``` yaml
url:
  base: 'another_url'
```

The combining of the above currently produces:

``` yaml
url:
  base: 'another_url'
```

It **deletes the extra keys** that might exist on `url`.

If `_.extend` gets replaced with `_.merge`, the result would be the expected:

``` yaml
url:
  base: 'another_url'
  other: 'some_string'
```
